### PR TITLE
Adicionando configuração de seed para banco de dados e dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# data dumps
+.json
+.bson

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     command: python -u api.py
     depends_on:
       - db
+      - mongo-seed
     ports:
       - 5000:5000
     volumes:
@@ -19,3 +20,10 @@ services:
     image: mongo
     ports:
       - 27017:27017
+
+  mongo-seed:
+    build: ./mongo-seed
+    depends_on:
+      - db
+    links:
+      - db

--- a/mongo-seed/Dockerfile
+++ b/mongo-seed/Dockerfile
@@ -1,0 +1,6 @@
+FROM mongo
+
+COPY db_dump/cardapios.bson /db_dump/cardapios.bson
+COPY db_dump/escolas.bson /db_dump/escolas.bson
+
+CMD mongorestore --host db:27017 --db pratoaberto --nsInclude 'pratoaberto.*s' /db_dump/


### PR DESCRIPTION
Co-authored-by: Josue <josuetk63@gmail.com>

Resolve a [Issue 5](https://github.com/prefeiturasp/SME-PratoAberto-API/issues/5)

Mudanças:
* Adiciona Dockerfile para configuração de seeds para o MongoDB
* Define configurações para arquivos de dump especificados na issue

Obs:
* Arquivos .bson devem ser adicionados na pasta mongo-seed/db_dump, seguindo o padrão de nomenclatura no plural, Ex: cardapio**s**.bson, escola**s**.bson
* O docker irá apresentar chaves duplicadas no banco quando for executado o docker-compose up após a primeira vez que o banco for alimentado, utilize o docker-compose down e docker-compose up novamente caso deseje ignorar.
* A documentação para toda configuração será feita no README no futuro.